### PR TITLE
:hammer: Refactor Cfdi::fromArray() and CoyfiObject

### DIFF
--- a/src/CoyfiObject.php
+++ b/src/CoyfiObject.php
@@ -12,7 +12,7 @@ abstract class CoyfiObject
         $this->fill($attributes);
     }
 
-    public static function create($attributes): static
+    public static function create($attributes)
     {
         $object = new static;
         $object->fill($attributes);

--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -13,7 +13,7 @@ class Subscription extends CoyfiObject
 
     public static function retrieve()
     {
-        $account = ApiResource::get('account');
+        $account = ApiResource::get('account') ?? [];
 
         return new self($account['activeSubscription']);
     }

--- a/src/Traits/HasFromArray.php
+++ b/src/Traits/HasFromArray.php
@@ -25,22 +25,23 @@ trait HasFromArray
 {
     public static function fromArray($attributes)
     {
-        $cfdi = new Cfdi([
-            ...isset($attributes['uuid']) ? ['uuid' => $attributes['uuid']] : [],
-            ...isset($attributes['xml']) ? ['xml' => $attributes['xml']] : [],
-            ...isset($attributes['total']) ? ['total' => $attributes['total']] : [],
-            ...isset($attributes['date']) ? ['date' => $attributes['date']] : [],
-            ...isset($attributes['status']) ? ['status' => $attributes['status']] : [],
+        $valid_fields = [
+            $attributes['uuid'] ? ['uuid' => $attributes['uuid']] : [],
+            $attributes['xml'] ? ['xml' => $attributes['xml']] : [],
+            $attributes['total'] ? ['total' => $attributes['total']] : [],
+            $attributes['date'] ? ['date' => $attributes['date']] : [],
+            $attributes['status'] ? ['status' => $attributes['status']] : [],
+            $attributes['invoice_number'] ? ['invoice_number' => $attributes['invoice_number']] : [],
+            $attributes['invoice_prefix'] ? ['invoice_prefix' => $attributes['invoice_prefix']] : [],
+            $attributes['cfdi_type'] ? ['cfdi_type' => $attributes['cfdi_type']] : [],
+            $attributes['payment_method'] ? ['payment_method' => $attributes['payment_method']] : [],
+            $attributes['payment_form'] ? ['payment_form' => $attributes['payment_form']] : [],
+            $attributes['payment_terms'] ? ['payment_terms' => $attributes['payment_terms']] : [],
 
-            ...isset($attributes['invoice_number']) ? ['invoice_number' => $attributes['invoice_number']] : [],
-            ...isset($attributes['invoice_prefix']) ? ['invoice_prefix' => $attributes['invoice_prefix']] : [],
-            ...isset($attributes['cfdi_type']) ? ['cfdi_type' => $attributes['cfdi_type']] : [],
-            ...isset($attributes['payment_method']) ? ['payment_method' => $attributes['payment_method']] : [],
-            ...isset($attributes['payment_form']) ? ['payment_form' => $attributes['payment_form']] : [],
-            ...isset($attributes['payment_terms']) ? ['payment_terms' => $attributes['payment_terms']] : [],
-            ...isset($attributes['pre_invoice']) ? ['pre_invoice' => $attributes['pre_invoice']] : [],
-        ]);
+        ];
 
+        $cfdi = new Cfdi($attributes);
+        
         if (isset($attributes['sign'])) {
             $cfdi->sign = new Sign($attributes['sign']);
         }

--- a/src/Traits/HasFromArray.php
+++ b/src/Traits/HasFromArray.php
@@ -25,22 +25,30 @@ trait HasFromArray
 {
     public static function fromArray($attributes)
     {
-        $valid_fields = [
-            $attributes['uuid'] ? ['uuid' => $attributes['uuid']] : [],
-            $attributes['xml'] ? ['xml' => $attributes['xml']] : [],
-            $attributes['total'] ? ['total' => $attributes['total']] : [],
-            $attributes['date'] ? ['date' => $attributes['date']] : [],
-            $attributes['status'] ? ['status' => $attributes['status']] : [],
-            $attributes['invoice_number'] ? ['invoice_number' => $attributes['invoice_number']] : [],
-            $attributes['invoice_prefix'] ? ['invoice_prefix' => $attributes['invoice_prefix']] : [],
-            $attributes['cfdi_type'] ? ['cfdi_type' => $attributes['cfdi_type']] : [],
-            $attributes['payment_method'] ? ['payment_method' => $attributes['payment_method']] : [],
-            $attributes['payment_form'] ? ['payment_form' => $attributes['payment_form']] : [],
-            $attributes['payment_terms'] ? ['payment_terms' => $attributes['payment_terms']] : [],
-
+        $validAttributes = [
+            'uuid',
+            'xml',
+            'total',
+            'date',
+            'status',
+            'invoice_number',
+            'invoice_prefix',
+            'cfdi_type',
+            'payment_method',
+            'payment_form',
+            'payment_terms',
+            'pre_invoice',
         ];
 
-        $cfdi = new Cfdi($attributes);
+        $cfdi = new Cfdi;
+
+        foreach ($attributes as $key => $value) {
+            if (in_array($key, $validAttributes) && $value !== null) {
+                $cfdi->$key = $value;
+            } else {
+                $cfdi->$key = null;
+            }
+        }
 
         if (isset($attributes['sign'])) {
             $cfdi->sign = new Sign($attributes['sign']);

--- a/src/Traits/HasFromArray.php
+++ b/src/Traits/HasFromArray.php
@@ -41,7 +41,7 @@ trait HasFromArray
         ];
 
         $cfdi = new Cfdi($attributes);
-        
+
         if (isset($attributes['sign'])) {
             $cfdi->sign = new Sign($attributes['sign']);
         }

--- a/src/Traits/HasFromArray.php
+++ b/src/Traits/HasFromArray.php
@@ -25,30 +25,21 @@ trait HasFromArray
 {
     public static function fromArray($attributes)
     {
-        $validAttributes = [
-            'uuid',
-            'xml',
-            'total',
-            'date',
-            'status',
-            'invoice_number',
-            'invoice_prefix',
-            'cfdi_type',
-            'payment_method',
-            'payment_form',
-            'payment_terms',
-            'pre_invoice',
-        ];
+        $cfdi = new Cfdi(array_merge(
+            isset($attributes['uuid']) ? ['uuid' => $attributes['uuid']] : [],
+            isset($attributes['xml']) ? ['xml' => $attributes['xml']] : [],
+            isset($attributes['total']) ? ['total' => $attributes['total']] : [],
+            isset($attributes['date']) ? ['date' => $attributes['date']] : [],
+            isset($attributes['status']) ? ['status' => $attributes['status']] : [],
 
-        $cfdi = new Cfdi;
-
-        foreach ($attributes as $key => $value) {
-            if (in_array($key, $validAttributes) && $value !== null) {
-                $cfdi->$key = $value;
-            } else {
-                $cfdi->$key = null;
-            }
-        }
+            isset($attributes['invoice_number']) ? ['invoice_number' => $attributes['invoice_number']] : [],
+            isset($attributes['invoice_prefix']) ? ['invoice_prefix' => $attributes['invoice_prefix']] : [],
+            isset($attributes['cfdi_type']) ? ['cfdi_type' => $attributes['cfdi_type']] : [],
+            isset($attributes['payment_method']) ? ['payment_method' => $attributes['payment_method']] : [],
+            isset($attributes['payment_form']) ? ['payment_form' => $attributes['payment_form']] : [],
+            isset($attributes['payment_terms']) ? ['payment_terms' => $attributes['payment_terms']] : [],
+            isset($attributes['pre_invoice']) ? ['pre_invoice' => $attributes['pre_invoice']] : []
+        ));
 
         if (isset($attributes['sign'])) {
             $cfdi->sign = new Sign($attributes['sign']);


### PR DESCRIPTION
In CoyfiObject->create method, the return type was removed because its not available in lower php versions. Same case with the spread operatore ...[] in the trait FromArray, this functionality was replaced.